### PR TITLE
use github actions provided github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This action attempts to get the URL of the PR associated with the current commit.
 
-## Inputs
-
-### `github-oauth-token`
-
-**Required** OAuth token used to interact with the GitHub API. Must have commit status read permissions
-
 ## Outputs
 
 ### `url`
@@ -17,9 +11,10 @@ The url of the PR
 ## Example usage
 
 ```
-uses: kceb/pull-request-url-action@v1
-with:
-  github-oauth-token: ${{ secrets.GITHUB_OAUTH_TOKEN }}
+- uses: kceb/pull-request-url-action@v1
+  id: pr-url
+
+- run: echo "${{ steps.pr-url.outputs.url }}"
 ```
 
 For more info on how to use outputs: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,7 @@ description: 'Get the pull request URL'
 inputs:
   github-oauth-token:
     description: 'OAuth token used to interact with the GitHub API. Must have commit status read permissions'
+    default: ${{ github.token }}
     required: true
 outputs:
   url:


### PR DESCRIPTION
Use the GitHub provided `${{ github.token }}` as the default so the user does not need to provide one.

Example of `actions/checkout` using the same [syntax](https://github.com/actions/checkout/blob/main/action.yml#L24).

*This update does **NOT** require existing users to change anything.*