### PR TITLE
trim trailing newline from the PR value

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ try {
     if (err) {
       throw err;
     }
-    const url = prNumber && `https://github.com/${ GITHUB_REPOSITORY }/pull/${ prNumber }`;
+    const url = prNumber && `https://github.com/${ GITHUB_REPOSITORY }/pull/${ prNumber.trim() }`;
     core.setOutput("url", url);
   });
 } catch (error) {


### PR DESCRIPTION
This PR removes the trailing newline (because of the `jq` command) from the returned url.

*These changes **MAY** affect existing users of this action (they may be already stripping the newline themselves). Consider bumping to `v2`*